### PR TITLE
Case insensitive login

### DIFF
--- a/include/UserModel.php
+++ b/include/UserModel.php
@@ -168,7 +168,7 @@ function validate() {
 		return null;
 	if(!$this->validateName($u->name))
 		return null;
-	$users = $this->getUsers("name='$u->name'");
+	$users = $this->getUsers("name='$u->name' COLLATE NOCASE");
 	if(!$users || $this->error)
 		return null;
 	foreach($users as $user) {
@@ -208,7 +208,7 @@ function validateLogin($name, $pass, $remember) {
 		$this->error = 'Invalid Password';
 		return false;
 	}
-	$users = $this->getUsers("name='$name'");
+	$users = $this->getUsers("name='$name' COLLATE NOCASE");
 	if($this->error)
 		return false;
 	if(!$users) {


### PR DESCRIPTION
Login currently requires the username to match the exact case used during registration. Mobile keyboards, for example, often auto-capitalize the first letter, and callsigns may be entered in any case. 

Quick 2-line change that adds `COLLATE NOCASE` to the two SQL queries that match usernames (login and cookie validation), so "w1abc", "W1ABC", and "w1Abc" all match the same account. No database migration or changes to stored data needed.